### PR TITLE
TransitionDown with batched input; GPU Knn

### DIFF
--- a/pointnet2/models/transition_down.py
+++ b/pointnet2/models/transition_down.py
@@ -1,42 +1,21 @@
 import torch
 import torch.nn as nn
-import pytorch_lightning as pl
-import numpy as np
-import pointnet2_ops._ext as _ext
+from pointnet2.utils.knn import kNN
+from pointnet2_ops import pointnet2_utils
 
-from scipy.spatial import distance
-   
-def kNN(self, p, idx, k):
-    '''
-    inputs
-        p: (n, 3) shaped torch Tensor
-        idx: (n * sampling_ratio, ) shaped torch Tensor
-        k: int
-    
-    outputs
-        neighbors: (n * sampling_ratio, k) shaped numpy array
-                   Each row is a point in x and each column is an index of a neighboring point.
-    '''
-    dist = distance.squareform(distance.pdist(p.cpu().detach().numpy()))
-    closest = np.argsort(dist, axis=1)
-    neighbors = closest[idx.cpu().detach().numpy(), 1:k+1]
-    
-    return neighbors
 
 class TransitionDown(nn.Module):
     def __init__(self, in_channels, out_channels, k, sampling_ratio):
         super().__init__()
-        
+
         self.in_channels = in_channels
         self.out_channels = out_channels
         self.k = k
         self.sampling_ratio = sampling_ratio
         self.mlp_layer = nn.Sequential(
             nn.Linear(self.in_channels, self.out_channels),
-            nn.BatchNorm1d(self.out_channels),
-            nn.ReLU(True)
-        )
-    
+            nn.BatchNorm1d(self.out_channels), nn.ReLU(True))
+
     def forward(self, x, p1):
         '''
         inputs
@@ -49,46 +28,45 @@ class TransitionDown(nn.Module):
         '''
         n = p1.shape[0]
         sampled_n = int(n * self.sampling_ratio)
-        
+
         # 1: Furthest Point Sampling
         p1 = p1.unsqueeze(0)
-        sampled_index = _ext.furthest_point_sampling(p1, sampled_n)
+        sampled_index = pointnet2_utils.furthest_point_sample(p1, sampled_n)
         sampled_index = sampled_index.squeeze(0).long()
         p1 = p1.squeeze(0)
         p2 = p1[sampled_index]
-        
+
         # 2: kNN & MLP
-        neighbors = kNN(p1, sampled_index, self.k) # "neighbors" is a (sampled_n, k) shaped numpy array.
-        
+        neighbors = kNN(p2, p1, self.k)  # neighbors: (sampled_n, k)
+
         # 2-1: Apply MLP onto each feature
-        mlp_x = self.mlp_layer(x) # "mlp_x" is a (n, out_channels) shaped torch Tensor.
-        
+        mlp_x = self.mlp_layer(x)  # mlp_x: (n, out_channels)
+
         # 2-2: Extract features based on neighbors
-        features = []
-        for i in range(sampled_n):
-            idx = neighbors[i, :]
-            feature = mlp_x[idx].unsqueeze(0)
-            features.append(feature)
-        features = torch.cat(features) # "features" is a (sampled_n, k, out_channels) shaped torch Tensor.
-        
+        features = mlp_x[neighbors]  # features: (sampled_n, k, out_channels)
+
         # 3: Local Max Pooling
-        y = self.local_max_pooling(features)
-        
+        y = torch.max(features, dim=1)[0]  # y: (sampled_n, out_channels)
+
         return y, p2
+
+if __name__ == "__main__":
+
+    N, k, sampling_ratio = 1024, 16, 0.25
+    in_channels, out_channels = 64, 128
+
+    x = torch.rand(N, in_channels).cuda()
+    p1 = torch.rand(N, 3).cuda()
+
+    print(f"Input: ")
+    print(f"x: {x.shape}")
+    print(f"p1: {p1.shape}")
+    trans_down = TransitionDown(in_channels, out_channels, k, sampling_ratio).cuda()
     
-    def local_max_pooling(self, features):
-        '''
-        inputs
-            features: (n * sampling_ratio, k, out_channels) shaped torch Tensor
-        
-        outputs
-            pooled_features: (n * sampling_ratio, out_channles) shaped torch Tensor
-        '''
-        pooled_features = []
-        for i in range(features.shape[0]):
-            feature = features[i]
-            pooled_feature = torch.max(feature, dim=0)[0].unsqueeze(0)
-            pooled_features.append(pooled_feature)
-        pooled_features = torch.cat(pooled_features) # "pooled_features" is a (n * sampling_ratio, out_channels) shaped torch Tensor.
-        
-        return pooled_features
+    y, p2 = trans_down(x, p1)
+
+    assert y.shape == (256, 128), f"y should have (256, 128) shape, but has {y.shape}." 
+    assert p2.shape == (256, 3), f"p2 should have (256, 3) shape, but has {p2.shape}."
+    print(f"Output: ")
+    print(f"y: {y.shape}")
+    print(f"p2: {p2.shape}")

--- a/pointnet2/models/transition_down.py
+++ b/pointnet2/models/transition_down.py
@@ -12,61 +12,74 @@ class TransitionDown(nn.Module):
         self.out_channels = out_channels
         self.k = k
         self.sampling_ratio = sampling_ratio
-        self.mlp_layer = nn.Sequential(
-            nn.Linear(self.in_channels, self.out_channels),
-            nn.BatchNorm1d(self.out_channels), nn.ReLU(True))
+        self.mlp = nn.Sequential(
+            nn.Conv1d(self.in_channels,
+                      self.out_channels,
+                      kernel_size=1,
+                      bias=False), nn.BatchNorm1d(self.out_channels),
+            nn.ReLU(True))
 
     def forward(self, x, p1):
         '''
         inputs
-            x: (n, in_channels) shaped torch Tensor (A set of feature vectors)
-            p1: (n, 3) shaped torch Tensor (3D coordinates)
+            x: (B, N, in_channels) shaped torch Tensor (A set of feature vectors)
+            p1: (B, N, 3) shaped torch Tensor (3D coordinates)
         
         outputs
-            y: (n * sampling_ratio, out_channels) shaped torch Tensor
-            p2: (n * sampling_ratio, 3) shaped torch Tensor
+            y: (B, M, out_channels) shaped torch Tensor
+            p2: (B, M, 3) shaped torch Tensor
+
+        M = N * sampling ratio
         '''
-        n = p1.shape[0]
-        sampled_n = int(n * self.sampling_ratio)
+        B, N, _ = x.shape
+        M = int(N * self.sampling_ratio)
 
         # 1: Furthest Point Sampling
-        p1 = p1.unsqueeze(0)
-        sampled_index = pointnet2_utils.furthest_point_sample(p1, sampled_n)
-        sampled_index = sampled_index.squeeze(0).long()
-        p1 = p1.squeeze(0)
-        p2 = p1[sampled_index]
+        p1_flipped = p1.transpose(1, 2).contiguous()
+        p2 = pointnet2_utils.gather_operation(
+            p1_flipped, pointnet2_utils.furthest_point_sample(
+                p1, M)).transpose(1, 2).contiguous()  # p2: (B, M, 3)
 
         # 2: kNN & MLP
-        neighbors = kNN(p2, p1, self.k)  # neighbors: (sampled_n, k)
+        neighbors = kNN(p2, p1, self.k)  # neighbors: (B * M, k)
 
         # 2-1: Apply MLP onto each feature
-        mlp_x = self.mlp_layer(x)  # mlp_x: (n, out_channels)
+        x_flipped = x.transpose(1, 2).contiguous()
+        mlp_x = self.mlp(x_flipped).transpose(
+            1, 2).contiguous()  # mlp_x: (B, N, out_channels)
 
         # 2-2: Extract features based on neighbors
-        features = mlp_x[neighbors]  # features: (sampled_n, k, out_channels)
+        features = mlp_x.view(-1, self.out_channels)[neighbors].view(
+            B, M, -1, self.out_channels)  # features: (B, M, k, out_channels)
 
         # 3: Local Max Pooling
-        y = torch.max(features, dim=1)[0]  # y: (sampled_n, out_channels)
+        y = torch.max(features, dim=2)[0]  # y: (B, M, out_channels)
 
         return y, p2
 
+
 if __name__ == "__main__":
 
-    N, k, sampling_ratio = 1024, 16, 0.25
+    B, N, k, sampling_ratio = 2, 1024, 16, 0.25
     in_channels, out_channels = 64, 128
+    M = int(N * sampling_ratio)
 
-    x = torch.rand(N, in_channels).cuda()
-    p1 = torch.rand(N, 3).cuda()
+    x = torch.rand(B, N, in_channels).cuda()
+    p1 = torch.rand(B, N, 3).cuda()
 
     print(f"Input: ")
     print(f"x: {x.shape}")
     print(f"p1: {p1.shape}")
-    trans_down = TransitionDown(in_channels, out_channels, k, sampling_ratio).cuda()
-    
+    trans_down = TransitionDown(in_channels, out_channels, k,
+                                sampling_ratio).cuda()
+
     y, p2 = trans_down(x, p1)
 
-    assert y.shape == (256, 128), f"y should have (256, 128) shape, but has {y.shape}." 
-    assert p2.shape == (256, 3), f"p2 should have (256, 3) shape, but has {p2.shape}."
+    assert y.shape == (
+        B, M, out_channels
+    ), f"y should have {(B, M, out_channels)} shape, but has {y.shape}."
+    assert p2.shape == (
+        B, M, 3), f"p2 should have {(B, M, 3)} shape, but has {p2.shape}."
     print(f"Output: ")
     print(f"y: {y.shape}")
     print(f"p2: {p2.shape}")

--- a/pointnet2/utils/knn.py
+++ b/pointnet2/utils/knn.py
@@ -11,8 +11,9 @@ def kNN(query, dataset, k):
         k: int
     
     outputs
-        neighbors: (B, N0, k) shaped torch Tensor.
+        neighbors: (B * N0, k) shaped torch Tensor.
                    Each row is the indices of a neighboring points.
+                   It is flattened along batch dimension.
     '''
     assert query.is_cuda and dataset.is_cuda, "Input tensors should be gpu tensors."
     assert query.dim() == 3 and dataset.dim(
@@ -38,8 +39,10 @@ def kNN(query, dataset, k):
         if not status:
             raise Exception("Index failed.")
         neighbors, _ = nns.knn_search(_query, k)
+        # calculate prefix sum of indices
         neighbors += N1 * i
         indices.append(torch.utils.dlpack.from_dlpack(neighbors.to_dlpack()))
 
+    # flatten indices
     indices = torch.cat(indices, dim=0)
     return indices

--- a/pointnet2/utils/knn.py
+++ b/pointnet2/utils/knn.py
@@ -2,32 +2,44 @@ import open3d as o3d
 import torch
 import torch.utils.dlpack
 
+
 def kNN(query, dataset, k):
     '''
     inputs
-        query: (n0, dim) shaped torch gpu Tensor.
-        dataset: (n1, dim) shaped torch gpu Tensor.
+        query: (B, N0, D) shaped torch gpu Tensor.
+        dataset: (B, N1, D) shaped torch gpu Tensor.
         k: int
     
     outputs
-        neighbors: (n0, k) shaped torch Tensor.
+        neighbors: (B, N0, k) shaped torch Tensor.
                    Each row is the indices of a neighboring points.
     '''
     assert query.is_cuda and dataset.is_cuda, "Input tensors should be gpu tensors."
-    assert query.dim() == 2 and dataset.dim(
-    ) == 2, "Input tensors should be 2D."
-    assert query.shape[1] == dataset.shape[
-        1], "Input tensors should have same dimension."
+    assert query.dim() == 3 and dataset.dim(
+    ) == 3, "Input tensors should be 3D."
+    assert query.shape[0] == dataset.shape[
+        0], "Input tensors should have same batch size."
+    assert query.shape[2] == dataset.shape[
+        2], "Input tensors should have same dimension."
+
+    B, N1, _ = dataset.shape
 
     query_o3d = o3d.core.Tensor.from_dlpack(
         torch.utils.dlpack.to_dlpack(query))
     dataset_o3d = o3d.core.Tensor.from_dlpack(
         torch.utils.dlpack.to_dlpack(dataset))
 
-    nns = o3d.core.nns.NearestNeighborSearch(dataset_o3d)
-    status = nns.knn_index()
-    if not status:
-        raise Exception("Index failed.")
-    indices, _ = nns.knn_search(query_o3d, k)
-    indices = torch.utils.dlpack.from_dlpack(indices.to_dlpack())
+    indices = []
+    for i in range(query_o3d.shape[0]):
+        _query = query_o3d[i]
+        _dataset = dataset_o3d[i]
+        nns = o3d.core.nns.NearestNeighborSearch(_dataset)
+        status = nns.knn_index()
+        if not status:
+            raise Exception("Index failed.")
+        neighbors, _ = nns.knn_search(_query, k)
+        neighbors += N1 * i
+        indices.append(torch.utils.dlpack.from_dlpack(neighbors.to_dlpack()))
+
+    indices = torch.cat(indices, dim=0)
     return indices

--- a/pointnet2/utils/knn.py
+++ b/pointnet2/utils/knn.py
@@ -1,0 +1,33 @@
+import open3d as o3d
+import torch
+import torch.utils.dlpack
+
+def kNN(query, dataset, k):
+    '''
+    inputs
+        query: (n0, dim) shaped torch gpu Tensor.
+        dataset: (n1, dim) shaped torch gpu Tensor.
+        k: int
+    
+    outputs
+        neighbors: (n0, k) shaped torch Tensor.
+                   Each row is the indices of a neighboring points.
+    '''
+    assert query.is_cuda and dataset.is_cuda, "Input tensors should be gpu tensors."
+    assert query.dim() == 2 and dataset.dim(
+    ) == 2, "Input tensors should be 2D."
+    assert query.shape[1] == dataset.shape[
+        1], "Input tensors should have same dimension."
+
+    query_o3d = o3d.core.Tensor.from_dlpack(
+        torch.utils.dlpack.to_dlpack(query))
+    dataset_o3d = o3d.core.Tensor.from_dlpack(
+        torch.utils.dlpack.to_dlpack(dataset))
+
+    nns = o3d.core.nns.NearestNeighborSearch(dataset_o3d)
+    status = nns.knn_index()
+    if not status:
+        raise Exception("Index failed.")
+    indices, _ = nns.knn_search(query_o3d, k)
+    indices = torch.utils.dlpack.from_dlpack(indices.to_dlpack())
+    return indices

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ h5py
 
 hydra-core==0.11.3
 pytorch-lightning==0.7.1
+open3d==0.12.0.0
 
 ./pointnet2_ops_lib/.


### PR DESCRIPTION
- Expand TransitionDown module to consume batched input
- GPU Knn search function

To test TransitionDown module, execute
```
python -m pointnet2.models.transition_down
```