### PR TITLE
revision of PartSegNetwork

### DIFF
--- a/pointnet2/models/point_transformer_layer.py
+++ b/pointnet2/models/point_transformer_layer.py
@@ -28,7 +28,7 @@ def idx_pt(pts, idx):
         
         
 class PointTransformerBlock(nn.Module):
-    def __init__(self, dim, k):
+    def __init__(self, dim, k=16):
         super().__init__()
         
         self.prev_linear = nn.Linear(dim, dim)
@@ -76,7 +76,7 @@ class PointTransformerBlock(nn.Module):
 
         agg = self.final_linear(agg) + x_pre
 
-        return agg
+        return agg, pos
         
 if __name__ == "__main__":
 

--- a/pointnet2/models/point_transformer_part_seg.py
+++ b/pointnet2/models/point_transformer_part_seg.py
@@ -1,14 +1,15 @@
 import torch.nn as nn
 
-from point_transformer_layer import PointTransformerBlock, PointTransformerLayer
-from transition_down import TransitionDown
-from transition_up import TransitionUp
+from .point_transformer_layer import PointTransformerBlock
+from .transition_down import TransitionDown
+from .transition_up import TransitionUp
+
 
 class PointTransformerPartSeg(nn.Module):
-    def __init__(self, N):
+    def __init__(self, in_channels, num_classes):
         super().__init__()
         
-        self.MLP0 = nn.Linear(3, 32)
+        self.MLP0 = nn.Linear(in_channels, 32)
         self.PTB0 = PointTransformerBlock(dim=32)
         
         # Encoder - Stage 1
@@ -62,72 +63,70 @@ class PointTransformerPartSeg(nn.Module):
                                 out_channels=32)
         self.PTB4_decode = PointTransformerBlock(dim=32)
         
-        self.MLP2 = nn.Sequential()
+        self.out = nn.Linear(32, num_classes)
         
     
-    def forward(self, points):
+    def forward(self, x, p):
         '''
         inputs
+            x: (B, N, in_channels) shaped torch Tensor
             points: (B, N, 3) shaped torch Tensor
-            
+
         outputs
-            
+            y: (B, N, num_classes) shaped torch Tensor
         '''
-        N = points.shape[1]
         
-        # Stage 0
-        p = points                  # p: (B, N, 3) shaped torch Tensor
-        x = MLP0(points)            # x: (B, N, 32) shaped torch Tensor
-        x1, p1 = PTB0(x, p)         # x1: (B, N, 32) shaped torch Tensor
+        # Stage 0                   # p: (B, N, 3) shaped torch Tensor
+        x = self.MLP0(x)                 # x: (B, N, 32) shaped torch Tensor
+        x1, p1 = self.PTB0(x, p)         # x1: (B, N, 32) shaped torch Tensor
                                     # p1: (B, N, 3) shaped torch Tensor
             
         # Encoder - Stage 1
-        x, p = TD1(x1, p1)          # x: (B, N/4, 64) shaped torch Tensor
+        x, p = self.TD1(x1, p1)          # x: (B, N/4, 64) shaped torch Tensor
                                     # p: (B, N/4, 3) shaped torch Tensor
-        x2, p2 = PTB1_encode(x, p)  # x2: (B, N/4, 64) shaped torch Tensor
+        x2, p2 = self.PTB1_encode(x, p)  # x2: (B, N/4, 64) shaped torch Tensor
                                     # p2: (B, N/4, 3) shaped torch Tensor
         
         # Encoder - Stage 2
-        x, p = TD2(x2, p2)          # x: (B, N/16, 128) shaped torch Tensor
+        x, p = self.TD2(x2, p2)          # x: (B, N/16, 128) shaped torch Tensor
                                     # p: (B, N/16, 3) shaped torch Tensor
-        x3, p3 = PTB2_encode(x, p)  # x3: (B, N/16, 128) shaped torch Tensor
+        x3, p3 = self.PTB2_encode(x, p)  # x3: (B, N/16, 128) shaped torch Tensor
                                     # p3: (B, N/16, 3) shaped torch Tensor
             
         # Encoder - Stage 3
-        x, p = TD3(x3, p3)          # x: (B, N/64, 256) shaped torch Tensor
+        x, p = self.TD3(x3, p3)          # x: (B, N/64, 256) shaped torch Tensor
                                     # p: (B, N/64, 3) shaped torch Tensor
-        x4, p4 = PTB3_encode(x, p)  # x4: (B, N/64, 256) shaped torch Tensor
+        x4, p4 = self.PTB3_encode(x, p)  # x4: (B, N/64, 256) shaped torch Tensor
                                     # p4: (B, N/64, 3) shaped torch Tensor
             
         # Encoder - Stage 4
-        x, p = TD4(x4, p4)
-        x, p = PTB4_encode(x, p)    # x: (B, N/256, 512) shaped torch Tensor
+        x, p = self.TD4(x4, p4)
+        x, p = self.PTB4_encode(x, p)    # x: (B, N/256, 512) shaped torch Tensor
                                     # p: (B, N/256, 3) shaped torch Tensor 
             
         # Middle stage
-        x = MLP1(x)
-        x, p = PTB_mid(x, p)        # x: (B, N/256, 512) shaped torch Tensor
+        x = self.MLP1(x)
+        x, p = self.PTB_mid(x, p)        # x: (B, N/256, 512) shaped torch Tensor
                                     # p: (B, N/256, 3) shaped torch Tensor
         
         # Decoder - Stage 1
-        x, p = TU1(x, p, x4, p4)
-        x, p = PTB1_decode(x, p)    # x: (B, N/64, 256) shaped torch Tensor
+        x, p = self.TU1(x, p, x4, p4)
+        x, p = self.PTB1_decode(x, p)    # x: (B, N/64, 256) shaped torch Tensor
                                     # p: (B, N/64, 3) shaped torch Tensor
         
         # Decoder - Stage 2
-        x, p = TU2(x, p, x3, p3)    
-        x, p = PTB2_decode(x, p)    # x: (B, N/16, 128) shaped torch Tensor
+        x, p = self.TU2(x, p, x3, p3)    
+        x, p = self.PTB2_decode(x, p)    # x: (B, N/16, 128) shaped torch Tensor
                                     # p: (B, N/16, 3) shaped torch Tensor
         
         # Decoder - Stage 3
-        x, p = TU3(x, p, x2, p2)
-        x, p = PTB3_decode(x, p)    # x: (B, N/4, 64) shaped torch Tensor
+        x, p = self.TU3(x, p, x2, p2)
+        x, p = self.PTB3_decode(x, p)    # x: (B, N/4, 64) shaped torch Tensor
                                     # p: (B, N/4, 3) shaped torch Tensor
         
         # Decoder - Stage 4
-        x, p = TU4(x, p, x1, p1)
-        x, p = PTB4_decode(x, p)    # x: (B, N, 32) shaped torch Tensor (pointwise feature vectors)
+        x, p = self.TU4(x, p, x1, p1)
+        x, p = self.PTB4_decode(x, p)    # x: (B, N, 32) shaped torch Tensor (pointwise feature vectors)
                                     # p: (B, N, 3) shaped torch Tensor (points)
         
-        # Output MLP Stage
-        
+        return self.out(x), p

--- a/pointnet2/models/transition_down.py
+++ b/pointnet2/models/transition_down.py
@@ -4,7 +4,7 @@ import sys
 
 sys.path.append("../utils")
 
-from knn import kNN, kNN_torch, index_points
+from ..utils.knn import kNN_torch, index_points
 from pointnet2_ops import pointnet2_utils
 
 

--- a/pointnet2/models/transition_up.py
+++ b/pointnet2/models/transition_up.py
@@ -1,3 +1,4 @@
+import torch
 import torch.nn as nn
 
 from pointnet2_ops import pointnet2_utils

--- a/test_partseg.py
+++ b/test_partseg.py
@@ -1,0 +1,43 @@
+import torch
+from torch.nn import CrossEntropyLoss
+from tqdm import trange
+
+from pointnet2.models.point_transformer_part_seg import PointTransformerPartSeg
+
+
+def main():
+    print('==> Testing Part Segmentation Network...')
+    B, N = 8, 5000
+    in_channels = 3
+    num_classes = 10
+
+    net = PointTransformerPartSeg(in_channels, num_classes).cuda()
+    optimizer = torch.optim.SGD(net.parameters(), lr=0.01, momentum=0.9)
+    crit = torch.nn.CrossEntropyLoss()
+
+    pbar = trange(10000)
+    for i in pbar:
+        optimizer.zero_grad()
+        x = torch.randn(B, N, in_channels).cuda()
+        p = torch.randn(B, N, 3).cuda()
+        target = torch.zeros((B*N,), dtype=torch.long).cuda()
+        y, out_p = net(x, p)
+        loss = crit(y.view(-1, num_classes), target)
+        loss.backward()
+        optimizer.step()
+        pbar.set_postfix({'Loss': loss.item()})
+
+        if i % 10 == 0:
+            torch.cuda.empty_cache()
+
+        if i == 0:
+            assert torch.all(torch.eq(p, out_p)), "point permuted!"
+            print('[Inputs] x, p')
+            print('    x.shape:', x.shape)
+            print('    p.shape:', p.shape)
+            print('[Outputs] y')
+            print('    y.shape:', y.shape)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I have modified Part Segmentation Network to make it run correctly.
To test it, run
```
python test_partseg.py
```
From the overfitting test, I have found some points to be improved.
1. Low GPU utility. GPU utility is below 30% for most of training time.
2. Slow running time. It takes 2.5 sec to forward a mini-batch with batch size as 8 and num_points as 5000.
3. Too high GPU cost. It costs ~10G memory to train the model with batch size as 8 and num_points as 5000, which means that we cannot train segmentation model with current implementation.